### PR TITLE
Lookup restructure

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,9 @@
     },
     sourceType: "module"
   },
+  rules: {
+    "comma-dangle": [2, "always-multiline"]
+  },
   extends: "standard",
   plugins: [
     "standard"

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Create a _composed_ form function passing in an optional config object.
 The _composed_ form function then consumes the `AST` and returns renderable object.
 
 ```js
-import composeForm from 'formalist-compose'
+import composeForm, {createFormConfig} from 'formalist-compose'
 import AST from './data.js'
 
 // create a 'composed' form function passing in option config object e.g. { prefix: 'user' }
-let formTemplate = composeForm()
+let formTemplate = composeForm(createFormConfig({ ... form config }))
 
 // pass the AST to the 'composed' form function
 let form = formTemplate(AST)

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -97,7 +97,7 @@ function compiler(store, formConfig) {
       var value = definition.get(_schemaMapping2.default.field.value);
       var errors = definition.get(_schemaMapping2.default.field.errors);
       var attributes = (0, _compileAttributes2.default)(definition.get(_schemaMapping2.default.field.attributes));
-      var Field = formConfig.fields[type];
+      var Field = formConfig.get('field', type);
       if (typeof Field !== 'function') {
         throw new Error('Expected the ' + type + ' field handler to be a function.');
       }
@@ -137,7 +137,7 @@ function compiler(store, formConfig) {
       var attributes = (0, _compileAttributes2.default)(definition.get(_schemaMapping2.default.attr.attributes));
       var children = definition.get(_schemaMapping2.default.attr.children);
       path = path.push(_schemaMapping2.default.attr.children);
-      var Attr = formConfig.attr;
+      var Attr = formConfig.get('attr');
       if (typeof Attr !== 'function') {
         throw new Error('Expected the attr handler to be a function.');
       }
@@ -174,7 +174,7 @@ function compiler(store, formConfig) {
       var attributes = (0, _compileAttributes2.default)(definition.get(_schemaMapping2.default.compoundField.attributes));
       var children = definition.get(_schemaMapping2.default.compoundField.children);
       path = path.push(_schemaMapping2.default.compoundField.children);
-      var CompoundField = formConfig.compoundField;
+      var CompoundField = formConfig.get('compoundField');
       if (typeof CompoundField !== 'function') {
         throw new Error('Expected the CompoundField handler to be a function.');
       }
@@ -216,7 +216,7 @@ function compiler(store, formConfig) {
       var children = contents.map(function (content, index) {
         return content.map(visit.bind(_this, contentsPath.push(index)));
       });
-      var Many = formConfig.many;
+      var Many = formConfig.get('many');
       if (typeof Many !== 'function') {
         throw new Error('Expected the many handler to be a function.');
       }
@@ -260,7 +260,7 @@ function compiler(store, formConfig) {
       var children = definition.get(_schemaMapping2.default.section.children);
       path = path.push(_schemaMapping2.default.section.children);
       if (!children) return;
-      var Section = formConfig.section;
+      var Section = formConfig.get('section');
       if (typeof Section !== 'function') {
         throw new Error('Expected the section handler to be a function.');
       }
@@ -297,7 +297,7 @@ function compiler(store, formConfig) {
       var children = definition.get(_schemaMapping2.default.group.children);
       path = path.push(_schemaMapping2.default.group.children);
       if (!children) return;
-      var Group = formConfig.group;
+      var Group = formConfig.get('group');
       if (typeof Group !== 'function') {
         throw new Error('Expected the group handler to be a function.');
       }

--- a/lib/create-config.js
+++ b/lib/create-config.js
@@ -1,0 +1,31 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = createConfig;
+function getField(config, type) {
+  var field = config[type] || config.default;
+  if (typeof field !== 'function') {
+    throw new Error('Could not resolve field: ' + type);
+  }
+  return field;
+}
+
+function createConfig() {
+  var config = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+  return {
+    get: function get(componentType, type) {
+      if (componentType === 'field') {
+        return getField(type);
+      } else {
+        var component = config[componentType];
+        if (typeof component !== 'function') {
+          throw new Error('Could not resolve component: ' + componentType);
+        }
+        return component;
+      }
+    }
+  };
+}

--- a/lib/create-form-config.js
+++ b/lib/create-form-config.js
@@ -1,0 +1,47 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = createFormConfig;
+/**
+ * Get a field based on type
+ * @param  {Object} fields Object containing fields and their functions as
+ * key/values
+ * @param  {String} type The field type
+ * @return {Function} The field render function
+ */
+function getField(fields, type) {
+  var field = fields[type] || fields.default;
+  if (typeof field !== 'function') {
+    throw new Error('Could not resolve field: ' + type);
+  }
+  return field;
+}
+
+/**
+ * Create a form configuration
+ * @param  {Object} config Object describing the structure of the form
+ * @return {Object} Accessors to get the form configuration based on component
+ * type.
+ */
+function createFormConfig() {
+  var config = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+  return {
+    get: function get(componentType, type) {
+      if (componentType === 'field') {
+        if (config.fields == null) {
+          throw new Error('Could not resolve fields configuration');
+        }
+        return getField(config.fields, type);
+      } else {
+        var component = config[componentType];
+        if (typeof component !== 'function') {
+          throw new Error('Could not resolve component: ' + componentType);
+        }
+        return component;
+      }
+    }
+  };
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,25 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.actionTypes = exports.actions = undefined;
+exports.actionTypes = exports.actions = exports.createFormConfig = exports.default = undefined;
 
 var _composer = require('./composer');
 
-var _composer2 = _interopRequireDefault(_composer);
+Object.defineProperty(exports, 'default', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_composer).default;
+  }
+});
+
+var _createFormConfig = require('./create-form-config');
+
+Object.defineProperty(exports, 'createFormConfig', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_createFormConfig).default;
+  }
+});
 
 var _fields = require('./actions/fields');
 
@@ -25,6 +39,5 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.default = _composer2.default;
 var actions = exports.actions = Object.assign({}, fieldActions, manyActions);
 var actionTypes = exports.actionTypes = fieldActionTypes;

--- a/package.json
+++ b/package.json
@@ -19,15 +19,12 @@
   },
   "scripts": {
     "build": "babel src --out-dir lib",
-    "precompile": "npm run clean",
-    "compile": "npm run build",
-    "watch": "wr 'npm run build' ./src",
+    "watch": "nodemon --watch src --exec 'npm run build' --ext js",
     "clean": "rm -rf ./lib/*",
-    "prepublish": "npm run compile",
     "test": "babel-node test | faucet",
     "posttest": "npm run lint",
     "lint": "eslint 'src/*.js' 'src/**/*.js' 'test/*.js' 'test/**/*.js'",
-    "watchlint": "wr 'npm run lint' ./src"
+    "watchlint": "nodemon --watch src --exec 'npm run lint'"
   },
   "devDependencies": {
     "@f/is-function": "^1.1.1",
@@ -38,8 +35,8 @@
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",
     "faucet": "0.0.1",
-    "tape": "^4.5.1",
-    "wr": "^1.3.1"
+    "nodemon": "^1.9.2",
+    "tape": "^4.5.1"
   },
   "dependencies": {
     "immutable": "^3.7.6",

--- a/src/compile-attributes.js
+++ b/src/compile-attributes.js
@@ -57,7 +57,7 @@ export default function compileAttributes (attributes) {
      */
     visitValue (definition) {
       return definition.get(schemaMapping.attributes.value)
-    }
+    },
   }
 
   /**

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -80,7 +80,7 @@ export default function compiler (store, formConfig) {
       let attributes = compileAttributes(
         definition.get(schemaMapping.field.attributes)
       )
-      let Field = formConfig.fields[type]
+      let Field = formConfig.get('field', type)
       if (typeof Field !== 'function') {
         throw new Error(`Expected the ${type} field handler to be a function.`)
       }
@@ -94,7 +94,7 @@ export default function compiler (store, formConfig) {
           name,
           value,
           errors,
-          attributes
+          attributes,
         })
       )
     },
@@ -123,7 +123,7 @@ export default function compiler (store, formConfig) {
       )
       let children = definition.get(schemaMapping.attr.children)
       path = path.push(schemaMapping.attr.children)
-      let Attr = formConfig.attr
+      let Attr = formConfig.get('attr')
       if (typeof Attr !== 'function') {
         throw new Error('Expected the attr handler to be a function.')
       }
@@ -134,7 +134,7 @@ export default function compiler (store, formConfig) {
         type,
         errors,
         attributes,
-        children: children.map(visit.bind(this, path))
+        children: children.map(visit.bind(this, path)),
       })
     },
 
@@ -161,7 +161,7 @@ export default function compiler (store, formConfig) {
       )
       let children = definition.get(schemaMapping.compoundField.children)
       path = path.push(schemaMapping.compoundField.children)
-      let CompoundField = formConfig.compoundField
+      let CompoundField = formConfig.get('compoundField')
       if (typeof CompoundField !== 'function') {
         throw new Error('Expected the CompoundField handler to be a function.')
       }
@@ -170,7 +170,7 @@ export default function compiler (store, formConfig) {
         hashCode,
         type,
         attributes,
-        children: children.map(visit.bind(this, path))
+        children: children.map(visit.bind(this, path)),
       })
     },
 
@@ -207,7 +207,7 @@ export default function compiler (store, formConfig) {
           )
         )
       })
-      let Many = formConfig.many
+      let Many = formConfig.get('many')
       if (typeof Many !== 'function') {
         throw new Error('Expected the many handler to be a function.')
       }
@@ -223,7 +223,7 @@ export default function compiler (store, formConfig) {
           attributes,
           template,
           children,
-          store
+          store,
         })
       )
     },
@@ -254,7 +254,7 @@ export default function compiler (store, formConfig) {
       let children = definition.get(schemaMapping.section.children)
       path = path.push(schemaMapping.section.children)
       if (!children) return
-      let Section = formConfig.section
+      let Section = formConfig.get('section')
       if (typeof Section !== 'function') {
         throw new Error('Expected the section handler to be a function.')
       }
@@ -265,7 +265,7 @@ export default function compiler (store, formConfig) {
           name,
           type,
           attributes,
-          children: children.map(visit.bind(this, path))
+          children: children.map(visit.bind(this, path)),
         })
       )
     },
@@ -294,7 +294,7 @@ export default function compiler (store, formConfig) {
       let children = definition.get(schemaMapping.group.children)
       path = path.push(schemaMapping.group.children)
       if (!children) return
-      let Group = formConfig.group
+      let Group = formConfig.get('group')
       if (typeof Group !== 'function') {
         throw new Error('Expected the group handler to be a function.')
       }
@@ -304,10 +304,10 @@ export default function compiler (store, formConfig) {
           hashCode,
           type,
           attributes,
-          children: children.map(visit.bind(this, path))
+          children: children.map(visit.bind(this, path)),
         })
       )
-    }
+    },
   }
 
   // Map over the root nodes

--- a/src/composer.js
+++ b/src/composer.js
@@ -27,7 +27,7 @@ export default function composer (config = {}) {
       render: () => {
         return compiler(store, config)
       },
-      store: store
+      store: store,
     }
   }
 }

--- a/src/create-form-config.js
+++ b/src/create-form-config.js
@@ -1,0 +1,39 @@
+/**
+ * Get a field based on type
+ * @param  {Object} fields Object containing fields and their functions as
+ * key/values
+ * @param  {String} type The field type
+ * @return {Function} The field render function
+ */
+function getField (fields, type) {
+  const field = fields[type] || fields.default
+  if (typeof field !== 'function') {
+    throw new Error(`Could not resolve field: ${type}`)
+  }
+  return field
+}
+
+/**
+ * Create a form configuration
+ * @param  {Object} config Object describing the structure of the form
+ * @return {Object} Accessors to get the form configuration based on component
+ * type.
+ */
+export default function createFormConfig (config = {}) {
+  return {
+    get: function (componentType, type) {
+      if (componentType === 'field') {
+        if (config.fields == null) {
+          throw new Error('Could not resolve fields configuration')
+        }
+        return getField(config.fields, type)
+      } else {
+        const component = config[componentType]
+        if (typeof component !== 'function') {
+          throw new Error(`Could not resolve component: ${componentType}`)
+        }
+        return component
+      }
+    },
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-import composer from './composer'
+export { default } from './composer'
+export { default as createFormConfig } from './create-form-config'
 import * as fieldActions from './actions/fields'
 import * as manyActions from './actions/many'
 import * as fieldActionTypes from './constants/action-types'
 
-export default composer
 export let actions = Object.assign({}, fieldActions, manyActions)
 export let actionTypes = fieldActionTypes

--- a/src/schema-mapping.js
+++ b/src/schema-mapping.js
@@ -7,31 +7,31 @@
 const schemaMapping = {
   visit: {
     type: 0,
-    definition: 1
+    definition: 1,
   },
   field: {
     name: 0,
     type: 1,
     value: 2,
     errors: 3,
-    attributes: 4
+    attributes: 4,
   },
   compoundField: {
     type: 0,
     attributes: 1,
-    children: 2
+    children: 2,
   },
   attr: {
     name: 0,
     type: 1,
     errors: 2,
     attributes: 3,
-    children: 4
+    children: 4,
   },
   group: {
     type: 0,
     attributes: 1,
-    children: 2
+    children: 2,
   },
   many: {
     name: 0,
@@ -39,25 +39,25 @@ const schemaMapping = {
     errors: 2,
     attributes: 3,
     template: 4,
-    contents: 5
+    contents: 5,
   },
   section: {
     name: 0,
     type: 1,
     attributes: 2,
-    children: 3
+    children: 3,
   },
   attributes: {
     visit: {
       type: 0,
-      definition: 1
+      definition: 1,
     },
     objectChildren: {
       key: 0,
-      children: 1
+      children: 1,
     },
-    value: 0
-  }
+    value: 0,
+  },
 }
 
 export default schemaMapping

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -19,7 +19,7 @@ test('it should compile an attributes AST', (nest) => {
       [
         ['1', 'One'],
         ['2', 'Two'],
-        ['3', 'Three']
+        ['3', 'Three'],
       ],
       'options are a correctly constructed array-like'
     )

--- a/test/fixtures/text-form.js
+++ b/test/fixtures/text-form.js
@@ -1,3 +1,5 @@
+import {createConfig} from '../../src'
+
 const Attr = ({name, children}) => {
   return [`start-attr:${name}`, children.join(), `end-attr:${name}`]
 }
@@ -21,13 +23,15 @@ const Many = ({name, children}) => {
 const Section = ({name, children}) => {
   return [`start-section:${name}`, children.join(), `end-section:${name}`]
 }
-export default {
+
+export default createConfig({
   attr: Attr,
   group: Group,
   many: Many,
   compoundField: CompoundField,
   section: Section,
   fields: {
+    default: Field,
     checkBox: Field,
     dateField: Field,
     dateTimeField: Field,
@@ -35,6 +39,6 @@ export default {
     radioButtons: Field,
     selectBox: Field,
     textArea: Field,
-    textField: Field
-  }
-}
+    textField: Field,
+  },
+})

--- a/test/fixtures/text-form.js
+++ b/test/fixtures/text-form.js
@@ -1,4 +1,4 @@
-import {createConfig} from '../../src'
+import {createFormConfig} from '../../src'
 
 const Attr = ({name, children}) => {
   return [`start-attr:${name}`, children.join(), `end-attr:${name}`]
@@ -24,7 +24,7 @@ const Section = ({name, children}) => {
   return [`start-section:${name}`, children.join(), `end-section:${name}`]
 }
 
-export default createConfig({
+export default createFormConfig({
   attr: Attr,
   group: Group,
   many: Many,

--- a/test/many.js
+++ b/test/many.js
@@ -92,7 +92,7 @@ test('it should handle `many` options', (nest) => {
         basePath,
         (contents) => ([
           'Too many things',
-          'Not enough things'
+          'Not enough things',
         ])
       )
     )


### PR DESCRIPTION
Change the way component lookups work and forms are defined. We now wrap the form definitions as they’re created using `createFormConfig` so that we can create more flexible component definitions. For example, we can pass in a single `field: { default: ... }` as part of the config and all field calls will fall through here.