### PR TITLE
Github action for publishing to npm on version tag push

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,10 @@
 name: publish
 on:
   push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+    # tags:
+    #   - 'v[0-9]+.[0-9]+.[0-9]+*'
+    branches:
+      - "nr/npm-publish-github-action"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,23 @@
+name: publish
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node 8
+        uses: actions/setup-node@v1
+        with:
+          node-version: 8
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install package dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build project
+        run: yarn run compile
+      - name: Publish to npm
+        run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,10 +1,9 @@
 name: publish
 on:
   push:
-    # tags:
-    #   - 'v[0-9]+.[0-9]+.[0-9]+*'
-    branches:
-      - "nr/npm-publish-github-action"
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
 jobs:
   npm-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - "nr/npm-publish-github-action"
 jobs:
-  build:
+  npm-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
       - name: Install package dependencies
         run: yarn install --frozen-lockfile
       - name: Build project
-        run: yarn run compile
+        run: yarn run build
       - name: Publish to npm
         run: npm publish --dry-run
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Build project
         run: yarn run build
       - name: Publish to npm
-        run: npm publish --dry-run
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This has been tested using a branch push with the `npm publish --dry-run`